### PR TITLE
Unban (unblock) fixes

### DIFF
--- a/sourcebans-web-theme-fluent/page_comms.tpl
+++ b/sourcebans-web-theme-fluent/page_comms.tpl
@@ -165,13 +165,13 @@
                           <span><i class="fas fa-hourglass-half"></i> Block length</span>
                           <span>{$ban.banlength}</span>
                         </li>
-                        {if $ban.unbanned}
+                        {if isset($ban.unbanned)}
                           <li>
                             <span><i class="fas fa-user-shield"></i> Unblock reason</span>
-                            {if $ban.ureason == ""}
+                            {if $ban.ub_reason == ""}
                               <span class="text:italic">No reason present</span>
                             {else}
-                              <span>{$ban.ureason}</span>
+                              <span>{$ban.ub_reason}</span>
                             {/if}
                           </li>
                           <li>


### PR DESCRIPTION
Sometimes $ban.unbanned is not set causing an Undefined array key warning. Introduced isset so reasonings are only looped when unbanned is actually present.

The key in $ban array for unbanned reason is "ub_reason". Updated to reflect and get actual Unban reason.